### PR TITLE
Fix import case sensitivity for App module

### DIFF
--- a/frontends/web/src/index.tsx
+++ b/frontends/web/src/index.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 
-import App from "./app";
+import App from "./App";
 import reportWebVitals from "./reportWebVitals";
 
 const root = ReactDOM.createRoot(


### PR DESCRIPTION
This PR fixes an import error where the application couldn't find the corresponding module due to case sensitivity issues.

Changed:
- Updated import statement from `import App from "./app"` to `import App from "./App"` to match the actual file name case

This resolves the module not found error that was occurring during build/runtime.